### PR TITLE
Improve setup wizard button focus visibility for colour-blind users

### DIFF
--- a/skins/Default/1080i/service-CoreELEC-Settings-wizard.xml
+++ b/skins/Default/1080i/service-CoreELEC-Settings-wizard.xml
@@ -125,8 +125,6 @@
                         <height>75</height>
                         <label />
                         <textoffsetx>45</textoffsetx>
-                        <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                        <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                     </control>
                     <control type="radiobutton" id="1407">
                         <left>570</left>
@@ -135,16 +133,12 @@
                         <height>75</height>
                         <label />
                         <textoffsetx>45</textoffsetx>
-                        <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                        <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                     </control>
                     <control type="button" id="1401">
                         <left>280</left>
                         <top>440</top>
                         <width>300</width>
                         <height>75</height>
-                        <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                        <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                         <label />
                         <font>font13_title</font>
                         <textcolor>white</textcolor>
@@ -155,8 +149,6 @@
                         <top>440</top>
                         <width>300</width>
                         <height>75</height>
-                        <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                        <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                         <label />
                         <font>font13_title</font>
                         <textcolor>white</textcolor>
@@ -434,8 +426,6 @@
                 <width>300</width>
                 <height>75</height>
                 <visible>true</visible>
-                <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                 <label />
                 <font>font13_title</font>
                 <textcolor>white</textcolor>
@@ -450,8 +440,6 @@
                 <width>300</width>
                 <height>75</height>
                 <visible>true</visible>
-                <texturefocus border="40" colordiffuse="button_focus">button-fo.png</texturefocus>
-                <texturenofocus colordiffuse="71FFFFFF" border="40">button-nofo.png</texturenofocus>
                 <label />
                 <font>font13_title</font>
                 <textcolor>white</textcolor>


### PR DESCRIPTION
## Purpose

This proposes an accessibility improvement to the CoreELEC first-run setup wizard for users who have difficulty distinguishing the existing focused and unfocused button states, including users with red/green colour-vision deficiency.

## Change

This removes the local `texturefocus` and `texturenofocus` overrides from the following controls in `service-CoreELEC-Settings-wizard.xml`:

* radio buttons `1406` and `1407`;
* buttons `1401` and `1402`;
* navigation buttons `1500` and `1501`.

This allows the applicable skin defaults to provide the focused and unfocused appearance.

## Testing

I tested the modified XML on a CoreELEC 22 Amlogic-NO nightly build on an Odroid N2+.

The focused and unfocused states were substantially easier for me to distinguish, including:

* the Previous and Next navigation buttons;
* the SSH and Samba options;
* the other setup-wizard buttons using these controls.

The controls remained usable and understandable in my testing.

## Background

The problem and testing are documented in this CoreELEC forum thread:

https://discourse.coreelec.org/t/ce-setup-buttons-are-problematic-for-colour-blind/55425

I am not a CoreELEC developer, so I am submitting the tested change for maintainer review. In particular, I would welcome confirmation that allowing the skin defaults to apply is the preferred implementation rather than defining replacement textures explicitly.
